### PR TITLE
Bundle analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 .DS_Store
 node_modules
+stats.json
 
 builds/dist
 builds/dist-esm

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "_build_tests": "npm run prebuild && tsc --project tsconfig.tests.json",
     "prebundle": "rimraf builds/bundle",
     "bundle": "webpack",
-    "bundle:analyze": "webpack-bundle-analyzer",
+    "bundle:analyze": "npm run bundle:analyze stats.json",
     "_bundle-tests": "webpack --config webpack.tests.config.js",
     "_test-browser-umd": "karma start --single-run --browsers HeadlessLittleLiar karma-umd.conf.js",
     "_test-node": "mocha --no-colors --reporter ./tests/reporter ./builds/dist-tests/tests/src.ts/test-*.js",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "_build_tests": "npm run prebuild && tsc --project tsconfig.tests.json",
     "prebundle": "rimraf builds/bundle",
     "bundle": "webpack",
+    "bundle:analyze": "webpack-bundle-analyzer",
     "_bundle-tests": "webpack --config webpack.tests.config.js",
     "_test-browser-umd": "karma start --single-run --browsers HeadlessLittleLiar karma-umd.conf.js",
     "_test-node": "mocha --no-colors --reporter ./tests/reporter ./builds/dist-tests/tests/src.ts/test-*.js",
@@ -77,6 +78,7 @@
     "tsconfig-paths": "^3.9.0",
     "typescript": "^3.9.7",
     "webpack": "^4.44.1",
+    "webpack-bundle-analyzer": "^3.8.0",
     "webpack-cli": "^3.3.12"
   }
 }


### PR DESCRIPTION
I added the Webpack bundle analyzer as dev-dependency in order to visualize and to keep track of the bundle size

```bash
npm install
npm run bundle:analyze
```


<img width="1786" alt="Screenshot 2020-09-14 at 13 01 41" src="https://user-images.githubusercontent.com/11219583/93073038-f421d880-f68a-11ea-8e89-a626309aaaa9.png">
